### PR TITLE
Update version to 0.9.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "librdkafka" %}
-{% set version = "0.9.3" %}
-{% set sha256 = "745ead036f0d5b732e1cd035a1f31fc23665f2982bf9d799742034e0a1bd0be9" %}
-{% set build = 1 %}
+{% set version = "0.9.4" %}
+{% set sha256 = "5007ad20a6753f709803e72c5f2c09483dcbce0f16b94b17cf677fb3e6045907" %}
+{% set build = 0 %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
**DO NOT MERGE**

~~Includes a feedstock re-render and two fixes:~~

* ~~LZ4 library is `lz4-c` package.~~
* ~~Force include and lib dirs in OSX too.~~

**Update**:

Moved re-render to https://github.com/conda-forge/librdkafka-feedstock/pull/3 and OSX tweaks + `lz4-c` fix to https://github.com/conda-forge/librdkafka-feedstock/pull/4