### PR TITLE
Use toolchain for compiler flags and fix lz4 library dependency.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,17 +1,9 @@
 #!/bin/bash
 
-if [ $(uname) == Darwin ]; then
-    COMP_CC=clang
-    COMP_CXX=clang++
-    export MACOSX_DEPLOYMENT_TARGET="10.9"
-    export CXXFLAGS="$CXXFLAGS -stdlib=libc++"
-    export LDFLAGS="$LDFLAGS -headerpad_max_install_names"
-else
-    export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
-    export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
-    export C_INCLUDE_PATH="$PREFIX/include"
-    export LIBRARY_PATH="$PREFIX/lib"
-fi
+export CFLAGS="${CFLAGS} -I${PREFIX}/include"
+export CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include"
+export CPPFLAGS="${CXXFLAGS}"
+export LDFLAGS="${LDFLAGS} -Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib"
 
 ./configure --prefix=$PREFIX
 make -j $CPU_COUNT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "librdkafka" %}
 {% set version = "0.9.3" %}
 {% set sha256 = "745ead036f0d5b732e1cd035a1f31fc23665f2982bf9d799742034e0a1bd0be9" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: {{ name }}
@@ -18,15 +18,16 @@ build:
 
 requirements:
   build:
+    - toolchain  # [unix]
     - zlib 1.2.*
     - openssl 1.0.*
     - libgsasl  # [not osx]
-    - lz4
+    - lz4-c
   run:
     - zlib 1.2.*
     - openssl 1.0.*
     - libgsasl  # [not osx]
-    - lz4
+    - lz4-c
 
 test:
   commands:
@@ -34,6 +35,9 @@ test:
     - test -f ${PREFIX}/lib/librdkafka++.so  # [linux]
     - test -f ${PREFIX}/lib/librdkafka.dylib  # [osx]
     - test -f ${PREFIX}/lib/librdkafka++.dylib  # [osx]
+
+    - conda inspect linkages {{ name }}  # [unix]
+    - conda inspect objects {{ name }}   # [osx]
 
 about:
   home: https://github.com/edenhill/librdkafka


### PR DESCRIPTION
The conda inspect statements help to identify whether the resulting
objects were linked to conda's or system's libraries.

See the toolchain's flags here: https://github.com/conda-forge/toolchain-feedstock/blob/master/recipe/activate.sh