### PR TITLE
Add run_exports with max_pin="x.x"

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.13
+    vmImage: macOS-10.14
   timeoutInMinutes: 360
   strategy:
     maxParallel: 8
@@ -42,7 +42,7 @@ jobs:
       source activate base
       echo "Configuring conda."
 
-      setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      setup_conda_rc ./ "./recipe" ./.ci_support/${CONFIG}.yaml
       export CI=azure
       source run_conda_forge_build_setup
       conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
@@ -53,24 +53,24 @@ jobs:
 
   - script: |
       source activate base
-      mangle_compiler ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      mangle_compiler ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Mangle compiler
 
   - script: |
       source activate base
-      make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      make_build_number ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Generate build number clobber file
 
   - script: |
       source activate base
-      conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+      conda build "./recipe" -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
     displayName: Build recipe
 
   - script: |
       source activate base
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
-      upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      upload_package ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -15,7 +15,7 @@ docker_image:
 lz4_c:
 - 1.8.3
 openssl:
-- 1.1.1a
+- 1.1.1
 pin_run_as_build:
   lz4-c:
     max_pin: x.x.x

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -19,7 +19,7 @@ macos_machine:
 macos_min_version:
 - '10.9'
 openssl:
-- 1.1.1a
+- 1.1.1
 pin_run_as_build:
   lz4-c:
     max_pin: x.x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ test:
 
 about:
   home: https://github.com/edenhill/librdkafka
-  license: BSD 2-clause
+  license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE
   summary: 'The Apache Kafka C/C++ client library'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,10 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
+  run_exports:
+    - {{ pin_subpackage("librdkafka", max_pin="x.x") }}
 
 requirements:
   build:


### PR DESCRIPTION
This PR specifies that downstream packages which depend on `librdkafka 1.3` will not be finicky about the patch version of `librdkafka` that's installed.  For instance, if they were built against `1.3.0`, they would still be willing to use `1.3.1` (if it existed).

Currently, the `max_pin` is [specified in `conda-forge-pinning` recipe][2], but this PR allows us to specify it here, in the `librdkafka` recipe itself.

More discussion in conda-forge/conda-forge-pinning-feedstock#482.

[1]: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/482
[2]: https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/28febc4ac317caad0de59d95fe2309875ad6e072/recipe/conda_build_config.yaml#L234-L235

---
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy`

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
